### PR TITLE
Fix panic when calling client.get_account_manager_info() more than once

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -341,6 +341,7 @@ impl tower::Service<Vec<treexml::Element>> for Transport {
             };
 
             let query_res = conn.query(req).await;
+            *state = Some(ConnState::Ready(conn));
 
             if let Err(e) = &query_res {
                 *state = Some(ConnState::Error(e.clone()));


### PR DESCRIPTION
This is the fix according to Upwork's task.